### PR TITLE
Implement std::error::Error for easier error handling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,6 +196,21 @@ pub enum Error {
     Ffi(&'static str),
 }
 
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Priority(s) => write!(f, "unable to set priority: {}", s),
+            Error::PriorityNotInRange(range) => {
+                write!(f, "priority must be within the range: {:?}", range)
+            }
+            Error::OS(i) => write!(f, "the operating system returned error code {}", i),
+            Error::Ffi(s) => write!(f, "FFI error: {}", s),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
 /// Platform-independent thread priority value.
 /// Should be in `[0; 100)` range. The higher the number is - the higher
 /// the priority.

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,10 +1,10 @@
 use rstest::rstest;
 
 #[rstest]
-fn should_be_possible_to_reset_the_same_priority() {
-    let current = thread_priority::get_current_thread_priority().unwrap();
-    let set_result = thread_priority::set_current_thread_priority(current);
-    assert_eq!(set_result, Ok(()));
+fn should_be_possible_to_reset_the_same_priority() -> Result<(), Box<dyn std::error::Error>> {
+    let current = thread_priority::get_current_thread_priority()?;
+    thread_priority::set_current_thread_priority(current)?;
+    Ok(())
 }
 
 #[rstest]


### PR DESCRIPTION
Currently the `thread_priority::Error` type does not implement Rust's standard error trait, `std::error::Error`. This means that user code cannot use the `?` operator in certain contexts. Examples include when using the `anyhow` error handling library or as part of a function that is generic over the type of error that may be returned (`Box<dyn std::error::Error>`). Some Rust libraries and developers may expect that types representing errors will implement `std::error::Error`.

This PR adds the trait implementation so that `thread_priority::Error` integrates more readily with the rest of the Rust ecosystem. 

As a demonstration, I also refactored the `should_be_possible_to_reset_the_same_priority()` unit test to work with the `?` operator. The code in the new unit test was a compile error until `std::error::Error` was implemented.
