### PR TITLE
Fix typo in doc comment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,7 +217,7 @@ impl std::error::Error for Error {}
 /// Should be in `[0; 100)` range. The higher the number is - the higher
 /// the priority.
 ///
-/// The only way to create such a value is a safe conversion from an 8-byte
+/// The only way to create such a value is a safe conversion from an 8-bit
 /// unsigned integer ([`u8`]):
 ///
 /// ```rust


### PR DESCRIPTION
- Fix typo "8-byte" to "8-bit" for the `u8` datatype